### PR TITLE
Split Images

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -70,8 +70,8 @@
   <build_export_depend>beacon</build_export_depend>
   <build_export_depend>cv2</build_export_depend>
   <build_export_depend>json</build_export_depend>
-  <build_depend>numpy</build_depend>
-  <build_depend>os</build_depend>
+  <build_export_depend>numpy</build_export_depend>
+  <build_export_depend>os</build_export_depend>
 
 
   <exec_depend>rospy</exec_depend>
@@ -80,12 +80,11 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>detect_beacon</exec_depend>
   <exec_depend>position_calculation</exec_depend>
-  <build_export_depend>beacon</build_export_depend>
   <exec_depend>cv2</exec_depend>
   <exec_depend>json</exec_depend>
   <exec_depend>beacon</exec_depend>
-  <build_depend>numpy</build_depend>
-  <build_depend>os</build_depend>
+  <exec_depend>numpy</exec_depend>
+  <exec_depend>os</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/scripts/Bakenerkenner_ROS.py
+++ b/scripts/Bakenerkenner_ROS.py
@@ -86,7 +86,7 @@ def Rectified_Image_callback(data):
 
     img_90 = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
 
-    # IGOR IGOR IGOR IGOR
+    # *****************Split images*****************************
     # Get the dimensions of the combined image
     height, width = img_90.shape[:2]
 
@@ -106,7 +106,7 @@ def Rectified_Image_callback(data):
     rearranged_pictures = [pictures[5], pictures[4], pictures[3], pictures[2], pictures[1]]
     for picture in rearranged_pictures:
         frame_copy = detect(picture, cfg, weights, classes)
-    # IGOR IGOR IGOR IGOR IGOR IGOR
+    # **********************************************************
 
 
     #frame_copy = detect(img_90,cfg,weights,classes) #original
@@ -121,8 +121,12 @@ def Rectified_Image_callback(data):
 if __name__ == '__main__':
     ## Load path to model config ##
     dirname = os.path.dirname(__file__)
+
+    #************ADD YOUR PATH HERE**********************
     cfg = os.path.join('/home/sudi/catkin_ws_beacons/src/darknet_ros_pck/darknet_ros/yolo_network_config/cfg/yolov4-tiny-custom.cfg')
     weights = os.path.join('/home/sudi/catkin_ws_beacons/src/darknet_ros_pck/darknet_ros/yolo_network_config/weights/yolov4-tiny-custom_best.weights')
+    #*****************************************************
+
     classes = ['bake', 'bake2']
     #Node initialisieren
     rospy.init_node("Bakenerkenner")

--- a/scripts/Bakenerkenner_ROS.py
+++ b/scripts/Bakenerkenner_ROS.py
@@ -86,7 +86,30 @@ def Rectified_Image_callback(data):
 
     img_90 = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
 
-    frame_copy = detect(img_90,cfg,weights,classes)
+    # IGOR IGOR IGOR IGOR
+    # Get the dimensions of the combined image
+    height, width = img_90.shape[:2]
+
+    # Calculate the width of each individual picture
+    picture_width = width // 6
+    w_to_cut = 245
+
+    # Crop the image into 6 separate regions
+    pictures = [img_90[:, i * picture_width+w_to_cut: (i + 1) * picture_width-w_to_cut] for i in range(6)]
+    pictures[3] = img_90[:, 3 * picture_width + w_to_cut + 20: (3 + 1) * picture_width - w_to_cut + 20]
+
+    # Rearrange the cropped regions in the correct order
+    # rearranged_pictures = [pictures[5], pictures[4], pictures[3], pictures[2], pictures[1]]
+    #for i in range(5):
+    #    frame_copy = detect(i,cfg,weights,classes)
+
+    rearranged_pictures = [pictures[5], pictures[4], pictures[3], pictures[2], pictures[1]]
+    for picture in rearranged_pictures:
+        frame_copy = detect(picture, cfg, weights, classes)
+    # IGOR IGOR IGOR IGOR IGOR IGOR
+
+
+    #frame_copy = detect(img_90,cfg,weights,classes) #original
 
     # frame zurück zu ROS-Image konvertieren
     frame_copy = bridge.cv2_to_imgmsg(frame_copy, encoding="bgr8")
@@ -98,8 +121,8 @@ def Rectified_Image_callback(data):
 if __name__ == '__main__':
     ## Load path to model config ##
     dirname = os.path.dirname(__file__)
-    cfg = os.path.join('/media/psf/CJ1/catkin_ws/src/darknet_ros/darknet_ros/yolo_network_config/cfg/yolov4-tiny-custom.cfg')
-    weights = os.path.join('/media/psf/CJ1/catkin_ws/src/darknet_ros/darknet_ros/yolo_network_config/weights/yolov4-tiny-custom_best.weights')
+    cfg = os.path.join('/home/sudi/catkin_ws_beacons/src/darknet_ros_pck/darknet_ros/yolo_network_config/cfg/yolov4-tiny-custom.cfg')
+    weights = os.path.join('/home/sudi/catkin_ws_beacons/src/darknet_ros_pck/darknet_ros/yolo_network_config/weights/yolov4-tiny-custom_best.weights')
     classes = ['bake', 'bake2']
     #Node initialisieren
     rospy.init_node("Bakenerkenner")


### PR DESCRIPTION
Add code to split images into 5

Note: the paths for .cfg and .weight files have been adjusted for my system, they need to be customized for everyone according to their system configuration:
cfg = os.path.join('<ADD YOUR PATH TO .cfg FILE>')
weights = os.path.join('<ADD YOUR PATH TO .weights FILE>')
    